### PR TITLE
Replace psycopg2 dependency with psycopg2-binary to avoid a deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.10.8
 coverage==3.6
 dj-database-url==0.2.1
 gunicorn==0.17.4
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 dj-static==0.0.6
 django-reversion==1.10.2
 django-axes==1.7.0


### PR DESCRIPTION
The `psycopg2 wheel` package will be renamed from release 2.8: http://initd.org/psycopg/docs/install.html#binary-install-from-pypi.