### PR TITLE
make the validation errors show in the add patient pathway

### DIFF
--- a/odonto/templates/pathway/templates/add_patient_base.html
+++ b/odonto/templates/pathway/templates/add_patient_base.html
@@ -11,7 +11,7 @@
     <button
     class="btn btn-lg btn-primary btn-save"
     ng-show="pathway.steps[0].scope.state !== 'initial'"
-    ng-click="(!pathway.errors && form.$valid) && pathway.finish(editing)"
+    ng-click="!form.$setSubmitted() && (!pathway.errors && form.$valid) && pathway.finish(editing)"
     ng-disabled="form.$submitted && (!form.$valid || pathway.errors)"
   >
     <i class="[[ pathway.finish_button_icon ]]"></i>


### PR DESCRIPTION
Previously we weren't showing validation errors in the add patient pathway, but the form wouldn't submit so the user just had to fill in all the fields. We now look like...

![Screen Shot 2019-07-18 at 13 49 57](https://user-images.githubusercontent.com/2175455/61459485-b6c99a00-a964-11e9-9eee-7c687b057d42.png)


