### PR TITLE
Change the get performer object method to iterate through user get fu…

### DIFF
--- a/odonto/models.py
+++ b/odonto/models.py
@@ -142,7 +142,7 @@ class Fp17DentalCareProvider(models.EpisodeSubrecord):
     def get_performer_obj(self):
         for user in User.objects.all():
             if user.get_full_name() == self.performer:
-                return user
+                return user.performernumber_set.first()
 
     class Meta:
         verbose_name = "Performer name and clinic"

--- a/odonto/models.py
+++ b/odonto/models.py
@@ -2,6 +2,7 @@
 Odonto models.
 """
 from django.db.models import fields
+from django.contrib.auth.models import User
 from django.db import models as djangomodels
 
 from opal import models
@@ -139,9 +140,9 @@ class Fp17DentalCareProvider(models.EpisodeSubrecord):
     )
 
     def get_performer_obj(self):
-        return PerformerNumber.objects.filter(
-            user__username=self.performer
-        ).first()
+        for user in User.objects.all():
+            if user.get_full_name() == self.performer:
+                return user
 
     class Meta:
         verbose_name = "Performer name and clinic"
@@ -530,7 +531,6 @@ class ExtractionChart(models.EpisodeSubrecord):
     ll_c = fields.BooleanField(default=False)
     ll_d = fields.BooleanField(default=False)
     ll_e = fields.BooleanField(default=False)
-
 
 
 class OrthodonticAssessment(models.EpisodeSubrecord):

--- a/odonto/test/test_models.py
+++ b/odonto/test/test_models.py
@@ -12,14 +12,29 @@ class GetPerformerObjectTestCase(OpalTestCase):
             first_name="Wilma",
             last_name="Flintstone"
         )
+        performer_number_obj = user.performernumber_set.create()
         care_provider = self.episode.fp17dentalcareprovider_set.create(
             performer=user.get_full_name(),
             provider_location_number='010108',
         )
         performer = care_provider.get_performer_obj()
         self.assertEqual(
-            user, performer
+            performer_number_obj, performer
         )
+
+    def test_get_user_but_performer_object_does_not_exist(self):
+        # for non dentists they will not have a performer obj
+        user = User.objects.create(
+            username="W.Flintstone",
+            first_name="Wilma",
+            last_name="Flintstone"
+        )
+        care_provider = self.episode.fp17dentalcareprovider_set.create(
+            performer=user.get_full_name(),
+            provider_location_number='010108',
+        )
+        performer = care_provider.get_performer_obj()
+        self.assertIsNone(performer)
 
     def test_get_performer_object_not_found(self):
         care_provider = self.episode.fp17dentalcareprovider_set.create(

--- a/odonto/test/test_models.py
+++ b/odonto/test/test_models.py
@@ -1,0 +1,38 @@
+from django.contrib.auth.models import User
+from opal.core.test import OpalTestCase
+
+
+class GetPerformerObjectTestCase(OpalTestCase):
+    def setUp(self):
+        _, self.episode = self.new_patient_and_episode_please()
+
+    def test_get_performer_object_found(self):
+        user = User.objects.create(
+            username="W.Flintstone",
+            first_name="Wilma",
+            last_name="Flintstone"
+        )
+        care_provider = self.episode.fp17dentalcareprovider_set.create(
+            performer=user.get_full_name(),
+            provider_location_number='010108',
+        )
+        performer = care_provider.get_performer_obj()
+        self.assertEqual(
+            user, performer
+        )
+
+    def test_get_performer_object_not_found(self):
+        care_provider = self.episode.fp17dentalcareprovider_set.create(
+            performer="someone",
+            provider_location_number='010108',
+        )
+        performer = care_provider.get_performer_obj()
+        self.assertIsNone(performer)
+
+    def test_performer_is_none(self):
+        care_provider = self.episode.fp17dentalcareprovider_set.create(
+            performer=None,
+            provider_location_number='010108',
+        )
+        performer = care_provider.get_performer_obj()
+        self.assertIsNone(performer)


### PR DESCRIPTION
…ll name, as this is what is currently saved in the form

I ummed and arred about raising an exception but I decided not too as we are usually forgiving and it would be picked up by serialization.

Other things to consider. 

Why is this done here not in the form?
So we could do it in the python in the form. however we would have to do it when serialising the existing data and deserialising which just feels like it has a high chance of going wrong.

Why aren't you doing it in javascript? For pretty much the same reason as above.

What happens if a person's performer number changes (typo or something)? Performer number is versioned and I think if this happens we would prefer not to have to update all care providers but rather update one place, the performer number.

What happens if the user's name changes (marriage etc). Well this is the risk, this then does mean we have to update all care providers if we want the message sending to be subsequently reproducible. Also User is not versioned...

Final thing to consider is that this makes the object more intuitive then having to look up the performer number.

Conclusion, I'm doing this because its less code and simpler. There is a risk of user changing their name however in the last four years in multiple opal systems I don't think this has ever happened so...



