### PR TITLE
removes the ExemptionsAndRemissionsValidator from the fp17O form

### DIFF
--- a/odonto/static/js/openodonto/controllers/check_fp17_o.step.controller.js
+++ b/odonto/static/js/openodonto/controllers/check_fp17_o.step.controller.js
@@ -14,7 +14,6 @@ angular.module('opal.controllers').controller(
   $rootScope.isFormValid = null;
   $rootScope.showSummary = null;
   var validators = [
-    ExemptionsAndRemissionsValidator,
     DateOfBirthRequired
   ];
 


### PR DESCRIPTION
If a patient starts treatment while under the age of 18, this is not added as an exemption. This means that it is possible to not have a valid exemption or pay.

IE we remove the exemption validation for FP17Os