### PR TITLE
Serializers take episodes not subrecords

### DIFF
--- a/odonto/odonto_submissions/serializers.py
+++ b/odonto/odonto_submissions/serializers.py
@@ -583,7 +583,7 @@ def get_fp17o_date_of_acceptance(episode):
 
 def translate_to_fp17o(bcds1, episode):
     demographics = episode.patient.demographics()
-    demographics_translator = DemographicsTranslator(demographics)
+    demographics_translator = DemographicsTranslator(episode)
     # surname must be upper case according to the form submitting guidelines
     bcds1.patient.surname = demographics_translator.surname()
     bcds1.patient.forename = demographics_translator.forename()

--- a/odonto/odonto_submissions/tests/test_serializors.py
+++ b/odonto/odonto_submissions/tests/test_serializors.py
@@ -173,13 +173,13 @@ class DemographicsTranslatorTestCase(OpalTestCase):
         self.demographics.ethnicity = "Other ethnic group"
         self.demographics.save()
         self.assertEqual(
-            serializers.DemographicsTranslator(self.demographics).ethnicity(),
+            serializers.DemographicsTranslator(self.episode).ethnicity(),
             treatments.ETHNIC_ORIGIN_ANY_OTHER_ETHNIC_GROUP
         )
 
     def test_without_ethnicity(self):
         with self.assertRaises(serializers.SerializerValidationError) as e:
-            serializers.DemographicsTranslator(self.demographics).ethnicity()
+            serializers.DemographicsTranslator(self.episode).ethnicity()
         self.assertEqual(
             str(e.exception), "Unable to find an ethnicity for patient"
         )
@@ -188,13 +188,13 @@ class DemographicsTranslatorTestCase(OpalTestCase):
         self.demographics.phone_number = "078 8761 9000"
         self.demographics.save()
         self.assertEqual(
-            serializers.DemographicsTranslator(self.demographics).phone_number(),
+            serializers.DemographicsTranslator(self.episode).phone_number(),
             "07887619000"
         )
         self.demographics.phone_number = "078-8761-9000"
         self.demographics.save()
         self.assertEqual(
-            serializers.DemographicsTranslator(self.demographics).phone_number(),
+            serializers.DemographicsTranslator(self.episode).phone_number(),
             "07887619000"
         )
 


### PR DESCRIPTION
This doesn't change behaviour but was a bug. The init method is below.

```
    def __init__(self, episode):
        self.episode = episode
        self.patient = episode.patient

        model_attribute_name = f"{self.model.__name__}_set".lower()

        if self.model in subrecords.patient_subrecords():
            parent = self.patient
        else:
            parent = self.episode
        self.model_instance = getattr(parent, model_attribute_name).get()
```

If you pass in a demographics instance or an episode to something with `self.model = Demographics` model instance instance will always be `demographics`, but the serializer _expects_ an episode to be passed in.


