### PR TITLE
Add a space between the version number and the brand name on the login

### DIFF
--- a/odontotheme/templates/registration/login.html
+++ b/odontotheme/templates/registration/login.html
@@ -13,7 +13,7 @@
       <img src="{% static 'img/odonto_logo.png' %}" />
     </center>
     <h2 class="text-center">
-      {{ OPAL_BRAND_NAME }}<small>{{ VERSION_NUMBER }}</small>
+      {{ OPAL_BRAND_NAME }} <small>{{ VERSION_NUMBER }}</small>
     </h2>
     {% if ODONTO_LOGIN_MESSAGE %}
     <h3 class="text-center">


### PR DESCRIPTION
This looks cluttered.

<img width="564" alt="Screen Shot 2020-04-09 at 09 40 52" src="https://user-images.githubusercontent.com/2175455/78875891-79eb8900-7a46-11ea-869e-d2d238f51481.png">

This looks better.
<img width="517" alt="Screen Shot 2020-04-09 at 09 44 35" src="https://user-images.githubusercontent.com/2175455/78876128-c636c900-7a46-11ea-8141-11b5fe9c1c19.png">

