### PR TITLE
Warnings about current tax year failings

### DIFF
--- a/odonto/episode_categories.py
+++ b/odonto/episode_categories.py
@@ -131,7 +131,6 @@ class AbstractOdontoCategory(object):
         start_of_today = timezone.make_aware(
             datetime.datetime.combine(datetime.date.today(), datetime.time.min)
         )
-        result["Sent today"] = qs.filter(submission__created__gte=start_of_today).count()
         result["Open"] = qs.filter(stage=cls.OPEN).count()
         result["Oldest unsent"] = None
         oldest_unsent = cls.get_oldest_unsent(qs)
@@ -148,7 +147,7 @@ class AbstractOdontoCategory(object):
                 # Therefore the most likely reason for no submission being sent down
                 # is that the submission failed due to a flaw in the form
                 # or that the patient has a protected address
-                result["Very recent, threw exception or protected address"] += 1
+                result["Not sent, needs investigation"] += 1
             else:
                 if submission.state == submission.SENT:
                     result["Sent (result pending)"] += 1

--- a/odonto/episode_categories.py
+++ b/odonto/episode_categories.py
@@ -15,6 +15,7 @@ class AbstractOdontoCategory(object):
     detail_template = None
     SUBMITTED = "Submitted"
     OPEN = "Open"
+    NEEDS_INVESTIGATION = "Not sent, needs investigation"
 
     def submission(self):
         """
@@ -147,7 +148,7 @@ class AbstractOdontoCategory(object):
                 # Therefore the most likely reason for no submission being sent down
                 # is that the submission failed due to a flaw in the form
                 # or that the patient has a protected address
-                result["Not sent, needs investigation"] += 1
+                result[cls.NEEDS_INVESTIGATION] += 1
             else:
                 if submission.state == submission.SENT:
                     result["Sent (result pending)"] += 1

--- a/odonto/odonto_submissions/management/commands/get_responses.py
+++ b/odonto/odonto_submissions/management/commands/get_responses.py
@@ -44,7 +44,6 @@ class Command(BaseCommand):
         episodes = Episode.objects.filter(
             category_name=episode_category.display_name
         )
-        current_tax_year = get_current_financial_year()[0]
         start_of_tax_year = get_current_financial_year()[0]
         episode_ids = set()
         for episode in episodes:

--- a/odonto/odonto_submissions/management/commands/get_responses.py
+++ b/odonto/odonto_submissions/management/commands/get_responses.py
@@ -31,7 +31,7 @@ class WarningField:
         self.warning = True
 
     def __str__(self):
-        self.value
+        return str(self.value)
 
     def __eq__(self, k):
         if not isinstance(k, WarningField):

--- a/odonto/odonto_submissions/management/commands/get_responses.py
+++ b/odonto/odonto_submissions/management/commands/get_responses.py
@@ -7,24 +7,69 @@ Then send an email with the current summary of the status quo so far.
 import json
 import traceback
 import datetime
+from collections import defaultdict
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 from django.core.mail import send_mail
+from opal.models import Episode
 from opal.core.serialization import OpalSerializer
 from odonto.odonto_submissions.models import Response, Submission
-from odonto.episode_categories import FP17Episode, FP17OEpisode
+from odonto.episode_categories import FP17Episode, FP17OEpisode, AbstractOdontoCategory
 from odonto.odonto_submissions import logger
+from odonto.utils import get_current_financial_year
+
+
+class WarningField:
+    """
+    A class to flag that a field should be marked
+    as needing a warning in the template
+    """
+    def __init__(self, value):
+        self.value = value
+        self.warning = True
+
+    def __str__(self):
+        self.value
+
+    def __eq__(self, k):
+        if not isinstance(k, WarningField):
+            return False
+        return self.value == k.value
 
 
 class Command(BaseCommand):
+    def filter_by_tax_year(self, episode_category):
+        episodes = Episode.objects.filter(
+            category_name=episode_category.display_name
+        )
+        current_tax_year = get_current_financial_year()[0]
+        start_of_tax_year = get_current_financial_year()[0]
+        episode_ids = set()
+        for episode in episodes:
+            sign_off_date = episode.category.get_sign_off_date()
+            if sign_off_date and sign_off_date >= start_of_tax_year:
+                episode_ids.add(episode.id)
+        return episodes.filter(id__in=episode_ids)
+
     def send_email(self, response):
-        context = {"summary": {}}
+        """
+        Sends an email with a context dict where...
+
+        title = the email subject.
+
+        summary = a dictionary of dictionaries that will be put on the page. If
+        it should be highlighted as a warning the result is cast to a WarningField
+        """
+
+
+        context = {"summary": {}, "warnings": defaultdict(dict)}
         successful = response.get_successfull_submissions()
         rejected = Submission.objects.filter(
             id__in=[i.id for i in response.get_rejected_submissions().keys()]
         )
+
         fp17_category = FP17Episode.display_name
         fp17o_category = FP17OEpisode.display_name
         context["summary"]["Latest response"] = {
@@ -33,16 +78,42 @@ class Command(BaseCommand):
             "FP17O Success": successful.filter(episode__category_name=fp17o_category).count(),
             "FP17O Rejected": rejected.filter(episode__category_name=fp17o_category).count(),
         }
-        context["summary"]["FP17"] = FP17Episode.summary()
-        context["summary"]["FP17O"] = FP17OEpisode.summary()
+
+        context["summary"]["FP17 current tax year"] = FP17Episode.summary(
+            self.filter_by_tax_year(FP17Episode)
+        )
+        error_states = [AbstractOdontoCategory.NEEDS_INVESTIGATION, Submission.REJECTED_BY_COMPASS]
+        warning = False
+
+        for error_state in error_states:
+            if error_state in context["summary"]["FP17 current tax year"]:
+                context["summary"]["FP17 current tax year"][error_state] = WarningField(
+                    context["summary"]["FP17 current tax year"][error_state]
+                )
+                warning = True
+
+        context["summary"]["FP17O current tax year"] = FP17OEpisode.summary(
+            self.filter_by_tax_year(FP17OEpisode)
+        )
+        for error_state in error_states:
+            if error_state in context["summary"]["FP17O current tax year"]:
+                context["summary"]["FP17O current tax year"][error_state] = WarningField(
+                    context["summary"]["FP17O current tax year"][error_state]
+                )
+                warning = True
+
+        context["summary"]["FP17 all time"] = FP17Episode.summary()
+        context["summary"]["FP17O all time"] = FP17OEpisode.summary()
         today = datetime.date.today()
-        title = f"Odonto response information for {today}"
+        if warning:
+            title = f"Odonto response information for {today}, NEEDS INVESTIGATION"
+        else:
+            title = f"Odonto response information for {today}"
         context["title"] = title
         html_message = render_to_string("emails/response_summary.html", context)
         plain_message = strip_tags(html_message)
         admin_emails = ", ".join([i[1] for i in settings.ADMINS])
         logger.info(f"sending email {title} to {admin_emails}")
-        logger.info(json.dumps(context, indent=4, cls=OpalSerializer))
         send_mail(
             title,
             plain_message,

--- a/odonto/odonto_submissions/management/commands/get_responses.py
+++ b/odonto/odonto_submissions/management/commands/get_responses.py
@@ -7,7 +7,6 @@ Then send an email with the current summary of the status quo so far.
 import json
 import traceback
 import datetime
-from collections import defaultdict
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.template.loader import render_to_string
@@ -61,9 +60,7 @@ class Command(BaseCommand):
         summary = a dictionary of dictionaries that will be put on the page. If
         it should be highlighted as a warning the result is cast to a WarningField
         """
-
-
-        context = {"summary": {}, "warnings": defaultdict(dict)}
+        context = {"summary": {}}
         successful = response.get_successfull_submissions()
         rejected = Submission.objects.filter(
             id__in=[i.id for i in response.get_rejected_submissions().keys()]

--- a/odonto/settings.py
+++ b/odonto/settings.py
@@ -159,7 +159,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    # 'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'axes',

--- a/odonto/templates/emails/response_summary.html
+++ b/odonto/templates/emails/response_summary.html
@@ -1,3 +1,4 @@
+{% load humanize %}
 <html>
 <body>
   <h1>{{ title }}</h1>
@@ -7,7 +8,10 @@
     {% for field, value in section.items %}
     <tr>
       <td {% if value.warning %}style="color: red"{% endif %} align="left">{{ field }}</td>
-      <td {% if value.warning %}style="color: red"{% endif %} align="right">{{ value }}</td>
+      <td {% if value.warning %}style="color: red"{% endif %} align="right">
+        {# if a value is a date, don't int comma it #}
+        {% if value.day %}{{ value }}{% else %}{{ value|intcomma }}{% endif %}
+      </td>
     </tr>
     {% endfor %}
   </table>

--- a/odonto/templates/emails/response_summary.html
+++ b/odonto/templates/emails/response_summary.html
@@ -6,8 +6,8 @@
   <table table width="280" cellpadding="0" cellspacing="0" border="0">
     {% for field, value in section.items %}
     <tr>
-      <td align="left">{{ field }}</td>
-      <td align="right">{{ value }}</td>
+      <td {% if value.warning %}style="color: red"{% endif %} align="left">{{ field }}</td>
+      <td {% if value.warning %}style="color: red"{% endif %} align="right">{{ value }}</td>
     </tr>
     {% endfor %}
   </table>

--- a/odonto/test/test_episode_categories.py
+++ b/odonto/test/test_episode_categories.py
@@ -186,22 +186,6 @@ translate_episode_to_xml"
         summary = FP17Episode.summary()
         self.assertEqual(summary["Open"], 1)
 
-    def test_summary_sent_today(self):
-        episode = self.get_episode()
-        episode.stage = FP17Episode.OPEN
-        episode.save()
-
-        summary = FP17Episode.summary()
-        self.assertEqual(summary["Sent today"], 0)
-
-
-        Submission.objects.create(
-            episode=episode,
-            state=Submission.SENT
-        )
-        summary = FP17Episode.summary()
-        self.assertEqual(summary["Sent today"], 1)
-
     def test_get_submit_link(self):
         episode = self.get_episode()
         l = f"http://ntghcomdent1/pathway/#/fp17-submit/{episode.patient.id}/{episode.id}"

--- a/odonto/test/test_views.py
+++ b/odonto/test/test_views.py
@@ -80,7 +80,7 @@ class GetContextDataStatsTestCase(OpalTestCase):
             "performer_info": {}
         }
 
-    @mock.patch('odonto.views.Stats.get_current_financial_year')
+    @mock.patch('odonto.views.get_current_financial_year')
     def test_single_current_fp17_episode(self, current_financial_year):
         current_financial_year.return_value = self.current_financial_year
         episode = self.new_fp17_episode()
@@ -126,7 +126,7 @@ class GetContextDataStatsTestCase(OpalTestCase):
         result = Stats().get_context_data()
         self.assertEqual(result, expected)
 
-    @mock.patch('odonto.views.Stats.get_current_financial_year')
+    @mock.patch('odonto.views.get_current_financial_year')
     def test_single_current_fp17o_episode(self, current_financial_year):
         current_financial_year.return_value = self.current_financial_year
         episode = self.new_fp17o_episode()

--- a/odonto/utils.py
+++ b/odonto/utils.py
@@ -1,3 +1,17 @@
 """
 Odonto utilities
 """
+import datetime
+
+
+def get_current_financial_year():
+    today = datetime.date.today()
+    if today.month > 3:
+        return (
+            datetime.date(today.year, 4, 1),
+            today
+        )
+    return (
+        datetime.date(today.year-1, 4, 1),
+        today
+    )

--- a/odonto/views.py
+++ b/odonto/views.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView, ListView, DetailView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from odonto import episode_categories
 from odonto import models
+from odonto.utils import get_current_financial_year
 from opal.models import Episode, Patient
 
 
@@ -75,20 +76,9 @@ class ViewFP17ODetailView(LoginRequiredMixin, DetailView):
 
 class Stats(LoginRequiredMixin, TemplateView):
     template_name = "stats.html"
-    def get_current_financial_year(self):
-        today = datetime.date.today()
-        if today.month > 3:
-            return (
-                datetime.date(today.year, 4, 1),
-                today
-            )
-        return (
-            datetime.date(today.year-1, 4, 1),
-            today
-        )
 
     def get_previous_financial_year(self):
-        current_start = self.get_current_financial_year()[0]
+        current_start = get_current_financial_year()[0]
         return (
             datetime.date(
                 current_start.year-1, current_start.month, current_start.day
@@ -143,7 +133,7 @@ class Stats(LoginRequiredMixin, TemplateView):
         result = {}
         monthly_claims = []
         time_periods = {
-            "current": self.get_current_financial_year(),
+            "current": get_current_financial_year(),
             "previous": self.get_previous_financial_year()
         }
         for period_name, period_range in time_periods.items():
@@ -158,7 +148,7 @@ class Stats(LoginRequiredMixin, TemplateView):
         return result
 
     def get_state_counts(self):
-        current_financial_year = self.get_current_financial_year()
+        current_financial_year = get_current_financial_year()
         return {
             "fp17s": {
                 "total": self.get_fp17_qs(current_financial_year).count(),
@@ -177,9 +167,9 @@ class Stats(LoginRequiredMixin, TemplateView):
         }
 
     def get_uoa_data(self):
-        current_financial_year = self.get_current_financial_year()
+        current_financial_year = get_current_financial_year()
         time_periods = {
-            "current": self.get_current_financial_year(),
+            "current": get_current_financial_year(),
             "previous": self.get_previous_financial_year()
         }
         by_period = defaultdict(list)
@@ -207,9 +197,9 @@ class Stats(LoginRequiredMixin, TemplateView):
         return by_period, by_performer
 
     def get_uda_data(self):
-        current_financial_year = self.get_current_financial_year()
+        current_financial_year = get_current_financial_year()
         time_periods = {
-            "current": self.get_current_financial_year(),
+            "current": get_current_financial_year(),
             "previous": self.get_previous_financial_year()
         }
         by_period = defaultdict(list)
@@ -244,7 +234,7 @@ class Stats(LoginRequiredMixin, TemplateView):
         performers = list(set(uda_performers + uoa_performers))
         performers = sorted(performers)
         fp17s = self.get_successful_fp17s(
-            self.get_current_financial_year()
+            get_current_financial_year()
         )
 
         for performer in performers:
@@ -265,7 +255,7 @@ class Stats(LoginRequiredMixin, TemplateView):
         return result
 
     def get_context_data(self):
-        current_financial_year = self.get_current_financial_year()
+        current_financial_year = get_current_financial_year()
         previous_financial_year = self.get_previous_financial_year()
         uda_by_period, uda_by_performer = self.get_uda_data()
         uoa_by_period, uoa_by_performer = self.get_uoa_data()


### PR DESCRIPTION
I removed `Sent today` from the summary as we now use the summary for both the current tax year and all time.

I may add sent today into the Latest response section and rename it, but that could be a different PR