### PR TITLE
It was the case that fp17o forms were submitting on enter, make sure …

### DIFF
--- a/odonto/templates/pathway/templates/pathway_base.html
+++ b/odonto/templates/pathway/templates/pathway_base.html
@@ -23,13 +23,13 @@
       </div>
 
       <div class="pathway-save-button content-offset-below-150">
-          <button
+          <a
           class="btn btn-lg btn-primary btn-save"
           ng-click="(!pathway.errors && form.$valid) && pathway.finish(editing)"
           ng-disabled="form.$submitted && (!form.$valid || pathway.errors)"
         >
           [[ pathway.finish_button_text ]]
-        </button>
+        </a>
       </div>
       {% endblock %}
     </form>


### PR DESCRIPTION
…this does not happen.

So the bug was that if you were in an FP17o form it was submitting if you pressend enter in a text box.

We didn't catch this because fo FP17s it did not happen as there was another <button></button> on the page (the set completion date to the same...) button. HTML logic says that on enter, find the first button tag and trigger its submit action so for fp17s this was not an issue...

This fixes it.
 