### PR TITLE
Sometimes we are using request from the template context processors o…

### DIFF
--- a/odontotheme/templates/opal.html
+++ b/odontotheme/templates/opal.html
@@ -37,7 +37,7 @@
 
           <div id="logout">
             <ul class="app-info">
-              {% if view.request.user.profile.can_extract %}
+              {% if request.user.profile.can_extract %}
               <li {% if request.resolver_match.url_name == "odonto-stats" %}class="active"{% endif %}>
                 <a href="{% url 'odonto-stats' %}">
                   <i class="fa fa-bar-chart"></i>
@@ -45,7 +45,7 @@
                 </a>
               </li>
               {% endif %}
-              {% if view.request.user.profile.can_extract %}
+              {% if request.user.profile.can_extract %}
                 <li>
                   <a href="/search/#/extract" title="Query">
                     <i class="fa fa-download"></i>
@@ -53,7 +53,7 @@
                   </a>
                 </li>
               {% endif %}
-              {% if view.request.user.is_superuser %}
+              {% if request.user.is_superuser %}
                 <li>
                   <a href="/admin/" title="Admin">
                     <i class="fa fa-cogs"></i>


### PR DESCRIPTION
…thertimes we are using it from the view. Lets be consistent accross the both and just use the context processors.

That stats page overrides get_context_data and does not call super() therefore view is not populated in the context data. 

I could change that, but that would break unit tests. Given the we are calling both view.request and request, we may as well just use request. 