### PR TITLE
Triage type

### DIFF
--- a/odonto/static/js/openodonto/controllers/check_covid_triage.step.controller.js
+++ b/odonto/static/js/openodonto/controllers/check_covid_triage.step.controller.js
@@ -34,7 +34,8 @@ angular.module('opal.controllers').controller(
     }
   }
   scope.$watch("editing", validate, true);
-  $rootScope.episodeSubmitted = step["episode_submitted"]
+  $rootScope.episodeSubmitted = step["episode_submitted"];
+  scope.pathway.validate = validate;
 
   $timeout(function(){
     scope.form.$setSubmitted();

--- a/odonto/static/js/openodonto/controllers/covid_triage.step.controller.js
+++ b/odonto/static/js/openodonto/controllers/covid_triage.step.controller.js
@@ -1,10 +1,10 @@
-angular.module('opal.controllers').controller('CovidTriageStepCtrl', function(scope, step, episode){
+angular.module('opal.controllers').controller('CovidTriageStepCtrl', function(scope, step, episode, $rootScope){
   "use strict";
   /*
   * This controller does 2 things.
   * 1. The form input for time returns a javascript date object,
-  *    the server wants a string in the form HH:MM:SS, so we change it onload from string to date
-  *    and back on save.
+  *    the server wants a string in the form HH:MM:SS, so onload we create a local variable as a date
+  *    when this local variable is updated we change that back into a HH:MM:SS on the editing variable
   * 2. The form has a check box for if the user is referred to urgent dental care. This is client
   *    only as the covid triage compass spec only requries a reason. The conrollter checks the checkbox
   *    if there is a reason.
@@ -12,7 +12,7 @@ angular.module('opal.controllers').controller('CovidTriageStepCtrl', function(sc
 
 
   var setUp = function(){
-    scope.local = {referred: false};
+    scope.local = {referred: false, time_of_contact: null};
     if(scope.editing.covid_triage.referrered_to_local_udc_reason){
       scope.local.referred = true;
     }
@@ -24,18 +24,26 @@ angular.module('opal.controllers').controller('CovidTriageStepCtrl', function(sc
       */
       var hoursAndMinute = scope.editing.covid_triage.time_of_contact.split(":")
       var timeDate = new Date();
-      timeDate.setHours(hoursAndMinute[0]);
-      timeDate.setMinutes(hoursAndMinute[1])
-      scope.editing.covid_triage.time_of_contact = timeDate;
+      timeDate.setHours(hoursAndMinute[0], hoursAndMinute[1], 0, 0);
+      scope.local.time_of_contact = timeDate;
+    }
+
+  }
+
+  scope.timeChange = function(){
+    var timeDate = scope.local.time_of_contact;
+    if(timeDate){
+      scope.editing.covid_triage.time_of_contact = "" + timeDate.getHours() + ":" + timeDate.getMinutes() + ":00";
+    }
+    else{
+      scope.editing.covid_triage.time_of_contact = null;
+    }
+    // the watch event will not trigger as we're in an ngchange so trigger validate manually
+    // if we're in the submit pathway
+    if(scope.pathway.validate){
+      scope.pathway.validate();
     }
   }
 
-  scope.preSave = function(editing){
-    if(scope.editing.covid_triage.time_of_contact){
-      var timeDate = scope.editing.covid_triage.time_of_contact;
-      editing.covid_triage.time_of_contact = "" + timeDate.getHours() + ":" + timeDate.getMinutes() + ":00";
-    }
-    return editing;
-  }
   setUp();
 });

--- a/odonto/static/js/openodonto/controllers/covid_triage.step.controller.js
+++ b/odonto/static/js/openodonto/controllers/covid_triage.step.controller.js
@@ -38,9 +38,11 @@ angular.module('opal.controllers').controller('CovidTriageStepCtrl', function(sc
     else{
       scope.editing.covid_triage.time_of_contact = null;
     }
-    // the watch event will not trigger as we're in an ngchange so trigger validate manually
-    // if we're in the submit pathway
-    if(scope.pathway.validate){
+
+    // The validate function is only set in the submit pathway by the check step.
+    // Usually validate is triggered by $watch but this
+    // will not trigger as we're in an ngchange so trigger validate manually
+    if(scope.pathway.hasOwnProperty("validate")){
       scope.pathway.validate();
     }
   }

--- a/odonto/static/js/openodonto/services/validators/covid_triage_time_of_contact.js
+++ b/odonto/static/js/openodonto/services/validators/covid_triage_time_of_contact.js
@@ -15,10 +15,9 @@ angular.module('opal.services').factory('CovidTriageTimeOfContact', function(toM
       if(editing.covid_triage.date_of_contact){
         var existingDates = _.map(step.other_triage, toMomentFilter);
         var ourDate = new Date(editing.covid_triage.date_of_contact);
-        var timeOfContact = editing.covid_triage.time_of_contact;
-        ourDate.setHours(
-          timeOfContact.getHours(), timeOfContact.getMinutes()
-        );
+        // time is stored as HH:MM:SS so translate it to a date for the equality,
+        var hoursAndMinute = editing.covid_triage.time_of_contact.split(":");
+        ourDate.setHours(hoursAndMinute[0], hoursAndMinute[1], 0, 0);
         var ourMoment = moment(ourDate);
         var error = false;
         _.each(existingDates, function(existingDate){

--- a/odonto/static/js/test/covid_triage.step.controller.test.js
+++ b/odonto/static/js/test/covid_triage.step.controller.test.js
@@ -2,6 +2,7 @@ describe('CovidTriageStepCtrl', function(){
   "use strict";
   var $controller;
   var scope;
+  var Pathway = function(){};
 
   beforeEach(function(){
     module('opal.controllers');
@@ -17,7 +18,7 @@ describe('CovidTriageStepCtrl', function(){
         referred: null,
         time_of_contact: null
       }
-      scope.pathway = {};
+      scope.pathway = new Pathway();
     });
   });
 

--- a/odonto/static/js/test/covid_triage.step.controller.test.js
+++ b/odonto/static/js/test/covid_triage.step.controller.test.js
@@ -13,6 +13,11 @@ describe('CovidTriageStepCtrl', function(){
       scope.editing = {
         covid_triage: {}
       }
+      scope.local = {
+        referred: null,
+        time_of_contact: null
+      }
+      scope.pathway = {};
     });
   });
 
@@ -29,30 +34,28 @@ describe('CovidTriageStepCtrl', function(){
     });
 
     it('should set the covid triage time of contact to a date on local.time_of_contact if populated', function(){
-      scope.editing.covid_triage.time_of_contact = "20:00";
+      scope.editing.covid_triage.time_of_contact = "20:00:00";
       $controller("CovidTriageStepCtrl", {scope: scope, step: {}, episode: {}});
-      expect(scope.editing.covid_triage.time_of_contact.getHours()).toBe(20);
-      expect(scope.editing.covid_triage.time_of_contact.getMinutes()).toBe(0);
+      expect(scope.local.time_of_contact.getHours()).toBe(20);
+      expect(scope.local.time_of_contact.getMinutes()).toBe(0);
     });
   });
 
-  describe('preSave', function(){
+  describe('timeChange', function(){
     it('should put the time onto the scope in the form we expect', function(){
       var timeOfContact = new Date();
-      timeOfContact.setHours(10);
-      timeOfContact.setMinutes(30);
-      var toSave = {covid_triage: {}};
+      timeOfContact.setHours(10, 30);
       $controller("CovidTriageStepCtrl", {scope: scope, step: {}, episode: {}});
-      scope.editing.covid_triage = {time_of_contact: timeOfContact};
-      scope.preSave(toSave);
-      expect(toSave.covid_triage.time_of_contact).toBe("10:30:00");
+      scope.local.time_of_contact = timeOfContact;
+      scope.timeChange();
+      expect(scope.editing.covid_triage.time_of_contact).toBe("10:30:00");
     });
 
     it('should not set time if there is nothing on the scope', function(){
-      var toSave = {covid_triage: {}};
       $controller("CovidTriageStepCtrl", {scope: scope, step: {}, episode: {}});
-      scope.preSave(toSave);
-      expect(toSave.covid_triage).toEqual({});
+      scope.local.time_of_contact = null;
+      scope.timeChange();
+      expect(scope.editing.covid_triage.time_of_contact).toBeNull();
     });
   });
 });

--- a/odonto/static/js/test/covid_triage.test.js
+++ b/odonto/static/js/test/covid_triage.test.js
@@ -35,7 +35,7 @@ describe('CovidTriageTimeOfContact', function() {
   describe('time of contact should not be the same as a different triage', function(){
     it('should error if there is a triage with the same date', function(){
       editing.covid_triage.date_of_contact = new Date(2020, 4, 21);
-      editing.covid_triage.time_of_contact = new Date(1900, 1, 1, 12, 40);
+      editing.covid_triage.time_of_contact = "12:40:00";
       step.other_triage = ["21/05/2020 12:40:00"]
       var result = CovidTriageTimeOfContact(editing, step);
       expect(result).toEqual({
@@ -47,15 +47,14 @@ describe('CovidTriageTimeOfContact', function() {
 
     it('should not error if there is a triage with the different date', function(){
       editing.covid_triage.date_of_contact = new Date(2020, 2, 22);
-      editing.covid_triage.time_of_contact = new Date(1900, 1, 1, 13, 40);
+      editing.covid_triage.time_of_contact = "13:40:00";
       step.other_triage = ["21/03/2020 12:40:00"]
       var result = CovidTriageTimeOfContact(editing, step);
       expect(result).toBeUndefined();
     });
 
     it('should not error if there is no triage date', function(){
-      editing.covid_triage.time_of_contact = new Date(1900, 1, 1, 11, 40);
-      step.other_triage = ["21/03/2020 12:40:00"]
+      editing.covid_triage.time_of_contact = "11:30:00";
       var result = CovidTriageTimeOfContact(editing, step);
       expect(result).toBeUndefined();
     });

--- a/odonto/templates/forms/covid_triage_form.html
+++ b/odonto/templates/forms/covid_triage_form.html
@@ -11,7 +11,7 @@
     {% odonto_datepicker field="CovidTriage.date_of_contact" %}
   </div>
   <div class="col-md-3 col-md-offset-1">
-    {% timefield field="CovidTriage.time_of_contact" %}
+    {% timefield field="CovidTriage.time_of_contact" model="local.time_of_contact" change="timeChange()" %}
   </div>
 </div>
 <div class="row">

--- a/odonto/templates/records/covid_triage.html
+++ b/odonto/templates/records/covid_triage.html
@@ -4,11 +4,11 @@
     <table class="table table-striped">
       {% table_row_field_display "CovidTriage.triage_type" %}
       {% table_row_field_display "CovidTriage.date_of_contact" %}
-      {% table_row_field_display "CovidTriage.time_of_contact" %} 
+      {% table_row_field_display "CovidTriage.time_of_contact" %}
       {% table_row_field_display "CovidTriage.dental_care_professional" %}
       {% table_row_field_display "CovidTriage.primary_reason" %}
       {% table_row_field_display "CovidTriage.covid_status" %}
-      {% table_row_field_display "CovidTriage.triage_via_video" %} 
+      {% table_row_field_display "CovidTriage.triage_via_video" %}
       {% table_row_field_display "CovidTriage.advice_given" %}
       {% table_row_field_display "CovidTriage.advised_analgesics" %}
       {% table_row_field_display "CovidTriage.remote_prescription_analgesics" %}

--- a/odonto/templates/templatetags/table_row_field_display.html
+++ b/odonto/templates/templatetags/table_row_field_display.html
@@ -8,6 +8,10 @@
       X
     {% elif is_date %}
       [[ {{ model }} | displayDate ]]
+    {% elif is_time %}
+      <span ng-if="{{ model }}">
+        [[ {{ model }}.substring(0, 5) ]]
+      </span>
     {% else %}
       [[ {{ model }} ]]
     {% endif %}

--- a/odonto/templatetags/odonto_subrecords.py
+++ b/odonto/templatetags/odonto_subrecords.py
@@ -35,6 +35,8 @@ def table_row_field_display(model_and_field):
         ctx["is_boolean"] = True
     if isinstance(field, models.DateField):
         ctx["is_date"] = True
+    if isinstance(field, models.TimeField):
+        ctx["is_time"] = True
     return ctx
 
 


### PR DESCRIPTION
So we have a continual issue that the time_of_contact on the server is stored as a string of HH:MM:SS but on the client the time picker returns a date.

This adds an ng-change to change the time in the timepicker into HH:MM so we always know the editing.covid_triage.time_of_contact is a string.

This is useful because when we show the summary page, it needs to know what kind of variable its dealing with and deals with both editing.covid_triage.time_of_contect and episode.covid_triage.time_of_contact. (Previously the former was a date and the latter a string)

However ng-change does not trigger the $watch event so we need to trigger validate manually whenever the time changes.

The final part is that in the summary page we want to show HH:MM rather than HH:MM:SS

