### PR TITLE
Instead of is submitted, use is successfully submitted, otherwise we …

### DIFF
--- a/odonto/pathways.py
+++ b/odonto/pathways.py
@@ -14,13 +14,9 @@ from odonto.episode_categories import (
 from plugins.add_patient_step import FindPatientStep
 
 
-def is_submitted(episode):
-    failed = [
-        submission_models.Submission.FAILED_TO_SEND,
-        submission_models.Submission.REJECTED_BY_COMPASS,
-    ]
-    return episode.submission_set.exclude(
-        state__in=failed
+def is_successfully_submitted(episode):
+    return episode.submission_set.filter(
+        state=submission_models.Submission.SUCCESS
     ).exists()
 
 
@@ -258,7 +254,7 @@ class SubmitFP17Pathway(OdontoPagePathway):
         to_dicted["steps"][check_index]["further_treatment_information"] = further_treatment_information
         free_repair_information = self.get_free_repair_replacement_information(patient, episode)
         to_dicted["steps"][check_index]["free_repair_replacement_information"] = free_repair_information
-        to_dicted["steps"][check_index]["episode_submitted"] = is_submitted(episode)
+        to_dicted["steps"][check_index]["episode_submitted"] = is_successfully_submitted(episode)
         return to_dicted
 
     @transaction.atomic
@@ -420,7 +416,7 @@ class SubmitFP17OPathway(OdontoPagePathway):
         to_dicted["steps"][check_index]
         overlapping_dates = self.get_overlapping_dates(patient, episode)
         to_dicted["steps"][check_index]["overlapping_dates"] = overlapping_dates
-        to_dicted["steps"][check_index]["episode_submitted"] = is_submitted(episode)
+        to_dicted["steps"][check_index]["episode_submitted"] = is_successfully_submitted(episode)
         to_dicted["steps"][check_index]["other_assessments"] = self.other_assessments(
             patient, episode
         )
@@ -503,7 +499,7 @@ class SubmitCovidTriagePathway(OdontoPagePathway):
         for index, step_dict in enumerate(to_dicted["steps"]):
             if step_dict["step_controller"] == step_ctrl:
                 check_index = index
-        to_dicted["steps"][check_index]["episode_submitted"] = is_submitted(episode)
+        to_dicted["steps"][check_index]["episode_submitted"] = is_successfully_submitted(episode)
         other_submitted = episode.patient.episode_set.filter(
             category_name=CovidTriageEpisode.display_name,
             stage=CovidTriageEpisode.SUBMITTED

--- a/odonto/test/test_pathways.py
+++ b/odonto/test/test_pathways.py
@@ -10,6 +10,7 @@ from odonto import episode_categories
 from odonto import pathways
 from odonto.odonto_submissions import models as submission_models
 
+
 class GetSubmissionStateTestCase(OpalTestCase):
     def setUp(self):
         _, self.episode = self.new_patient_and_episode_please()
@@ -18,16 +19,17 @@ class GetSubmissionStateTestCase(OpalTestCase):
         self.episode.submission_set.create(
             state=submission_models.Submission.SUCCESS
         )
-        self.assertTrue(pathways.is_submitted(self.episode))
+        self.assertTrue(pathways.is_successfully_submitted(self.episode))
 
     def test_is_submitted_failed(self):
         self.episode.submission_set.create(
             state=submission_models.Submission.FAILED_TO_SEND
         )
-        self.assertFalse(pathways.is_submitted(self.episode))
+        self.assertFalse(pathways.is_successfully_submitted(self.episode))
 
     def test_is_submitted_none(self):
-        self.assertFalse(pathways.is_submitted(self.episode))
+        self.assertFalse(pathways.is_successfully_submitted(self.episode))
+
 
 class AddPatientPathwayTestCase(OpalTestCase):
     def test_save(self):
@@ -248,10 +250,9 @@ class SubmitFP17PathwayTestCase(OpalTestCase):
             }]
         )
 
-
     def test_episode_submitted(self):
         self.episode.submission_set.create(
-            state="SUCCESS"
+            state=submission_models.Submission.SUCCESS
         )
         result = self.client.get(self.url).json()['steps'][-1]
         self.assertTrue(result["episode_submitted"])
@@ -406,7 +407,7 @@ class SubmitFP17OPathwayTestCase(OpalTestCase):
 
     def test_episode_submitted(self):
         self.episode.submission_set.create(
-            state="SUCCESS"
+            state=submission_models.Submission.SUCCESS
         )
         result = self.client.get(self.url).json()['steps'][-1]
         self.assertTrue(result["episode_submitted"])


### PR DESCRIPTION
…get race conditions where an episode is failing but its still in the sent state as we've resent it