### PR TITLE
Upgrades dependencies

### DIFF
--- a/odonto/settings.py
+++ b/odonto/settings.py
@@ -162,7 +162,6 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'axes',
     'reversion',
     'rest_framework',
     'rest_framework.authtoken',

--- a/plugins/add_patient_step/api.py
+++ b/plugins/add_patient_step/api.py
@@ -7,7 +7,7 @@ from opal.core.views import json_response
 
 
 class DemographicsSearch(LoginRequiredViewset):
-    base_name = 'demographics-search'
+    basename = 'demographics-search'
     PATIENT_FOUND_IN_APPLICATION = "patient_found_in_application"
     PATIENT_NOT_FOUND = "patient_not_found"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,25 @@
 # cryptography is required for heroku deployment
 # cryptography==1.3.2
-django==2.0.13
+django==2.2.16
 coverage==4.5.4
 dj-database-url==0.2.1
 gunicorn==0.17.4
-psycopg2==2.7.5
+psycopg2==2.8.6
 dj-static==0.0.6
-django-reversion==3.0.1
-django-axes==1.7.0
+django-reversion==3.0.8
 ffs==0.0.8.2
-letter==0.5
-requests==2.22.0
-djangorestframework==3.10.2
-django-compressor==2.2
-python-dateutil==2.8.0
+requests==2.25.0
+djangorestframework==3.12.2
+django-compressor==2.4
+python-dateutil==2.8.1
 xmlschema==0.9.20
 lxml==4.1.1
 cerberus==1.1
-click==6.7
+click==7.0
 # django-celery==3.1.17
 # celery==3.1.25
 
 # Open Health Care repositories
-opal==0.18.4
+opal==0.22.2
 
 -e git+https://github.com/openhealthcare/opal-passwordreset@v0.1#egg=opal_passwordreset


### PR DESCRIPTION
Upgrades opal from 0.18.4 to 0.22.2.

This means upgrades to for example djangorestframework. This means we
need to rename base_name to basename as part of this change.