### PR TITLE
Test fixes

### DIFF
--- a/odonto/odonto_submissions/tests/test_send_submissions.py
+++ b/odonto/odonto_submissions/tests/test_send_submissions.py
@@ -2,7 +2,7 @@ import datetime
 from unittest.mock import patch
 from django.test import override_settings
 from opal.core.test import OpalTestCase
-from opal.models import Episode
+from opal.models import Episode, Ethnicity
 from odonto.odonto_submissions import models
 from odonto.episode_categories import FP17Episode, FP17OEpisode
 from odonto.odonto_submissions.management.commands import send_submissions
@@ -20,6 +20,7 @@ class SendSubmissionEmailTestCase(OpalTestCase):
     has been sent downstream
     """
     def setUp(self):
+        Ethnicity.objects.create(name="Other mixed background")
         self.cmd = send_submissions.Command()
         self.patient, self.episode = self.new_patient_and_episode_please()
         self.episode.stage = "Submitted"
@@ -45,7 +46,7 @@ class SendSubmissionEmailTestCase(OpalTestCase):
     def test_success_fp17o(self, logger, render_to_string, send_submission, send_email):
         self.episode.category_name = FP17OEpisode.display_name
         self.episode.save()
-        self.patient.demographics_set.update(ethnicity_fk_id=1)
+        self.patient.demographics_set.update(ethnicity_fk_id=Ethnicity.objects.first().id)
         self.episode.orthodonticassessment_set.update(
             date_of_referral=self.yesterday, date_of_assessment=self.today
         )
@@ -57,7 +58,7 @@ class SendSubmissionEmailTestCase(OpalTestCase):
         send_submission.side_effect = ValueError("boom")
         self.episode.category_name = FP17OEpisode.display_name
         self.episode.save()
-        self.patient.demographics_set.update(ethnicity_fk_id=1)
+        self.patient.demographics_set.update(ethnicity_fk_id=Ethnicity.objects.first().id)
         self.episode.orthodonticassessment_set.update(
             date_of_referral=self.yesterday, date_of_assessment=self.today
         )
@@ -92,8 +93,9 @@ class SendSubmissionGetQSTestCase(OpalTestCase):
         self.fp17o_episode.stage = FP17OEpisode.SUBMITTED
         self.fp17o_episode.category_name = FP17OEpisode.display_name
         self.fp17o_episode.save()
+        Ethnicity.objects.create(name="Other mixed background")
         self.fp17o_episode.patient.demographics_set.update(
-            ethnicity_fk_id=1
+            ethnicity_fk_id=Ethnicity.objects.first().id
         )
         self.fp17o_episode.orthodonticassessment_set.update(
             date_of_assessment=today,

--- a/odonto/static/js/openodonto/controllers/check_covid_triage.step.controller.js
+++ b/odonto/static/js/openodonto/controllers/check_covid_triage.step.controller.js
@@ -11,7 +11,7 @@ angular.module('opal.controllers').controller(
     CovidTriageCovidStatusRequired,
     CovidTriageDateTimeOfContact,
     CovidTriagePrimaryReasonRequired,
-    CovidTriageTypeRequired,
+    CovidTriageTypeRequired
 ){
   "use strict";
   $rootScope.isFormValid = null;


### PR DESCRIPTION
The below changes are things that break when using CI.

The reason for the python change is that when sqlite runs tests it does not enforce the existence of FK relationships. IE when its run locally there are no ethnicities but sqlite does not blow up.

The reason for the javascript change is that in theory you should not have the last element of a list of arguments suffixed with a comma. Chrome/phantomks does not mind but the firefox browser we are running tests with on CI does.