### PR TITLE
Remove the sending down of exemptions for completion type fp17os

### DIFF
--- a/odonto/odonto_submissions/serializers.py
+++ b/odonto/odonto_submissions/serializers.py
@@ -917,11 +917,21 @@ def translate_to_fp17o(bcds1, episode):
     fp17_exemption = episode.fp17exemptions_set.get()
     if fp17_exemption.commissioner_approval:
         bcds1.treatments.append(t.COMMISSIONER_APPROVAL)
+
+    # Compass will reject invalid exemptions on completion types
+    # however they have explicitly stated that we should strip
+    # out all exemptions as completions don't generate UOAs
+    # and therefore charges have no meaning.
+    #
+    # Their email states
+    # "Everything can be stripped including Commissioner Approval as it  is
+    # only relevant for assessment claims"
     exemption_translator = ExceptionSerializer(fp17_exemption)
-    exemptions = exemption_translator.exemptions()
+    if not orthodontic_treatment.completion_type:
+        exemptions = exemption_translator.exemptions()
+        if exemptions:
+            bcds1.exemption_remission = exemptions
     charge = exemption_translator.charge()
-    if exemptions:
-        bcds1.exemption_remission = exemptions
     if charge:
         bcds1.patient_charge_pence = charge
     return bcds1

--- a/odonto/odonto_submissions/supplier_testing/fp17o/case_02.py
+++ b/odonto/odonto_submissions/supplier_testing/fp17o/case_02.py
@@ -15,10 +15,6 @@ def annotate(bcds1):
     bcds1.date_of_acceptance = datetime.date(2019, 10, 12)
     bcds1.date_of_completion = datetime.date(2019, 10, 12)
 
-    bcds1.exemption_remission = {
-        'code': exemptions.PATIENT_UNDER_18.EVIDENCE_SEEN
-    }
-
     bcds1.treatments = [
         treatments.COMPLETED_TREATMENT,
         treatments.EMAIL_DECLINED,

--- a/odonto/odonto_submissions/supplier_testing/fp17o/case_03.py
+++ b/odonto/odonto_submissions/supplier_testing/fp17o/case_03.py
@@ -16,10 +16,6 @@ def annotate(bcds1):
     bcds1.date_of_acceptance = datetime.date(2019, 10, 12)
     bcds1.date_of_completion = datetime.date(2019, 10, 12)
 
-    bcds1.exemption_remission = {
-        'code': exemptions.PATIENT_UNDER_18.EVIDENCE_SEEN,
-    }
-
     bcds1.treatments = [
         treatments.ETHNIC_ORIGIN_PATIENT_DECLINED,
         treatments.TREATMENT_ABANDONED,


### PR DESCRIPTION
Compass validate these even though we have been explicitly told they can be stripped out. Exemptions aren't relevant as these claims do not generate UOAs