### PR TITLE
Bug fixes the BPE submission to handle empty strings.

### DIFF
--- a/odonto/odonto_submissions/serializers.py
+++ b/odonto/odonto_submissions/serializers.py
@@ -256,7 +256,7 @@ class Fp17ClinicalDataSetSerializer(TreatmentSerializer):
                 treatments.append(t.CUSTOM_MADE_OCCLUSAL_APPLIANCE_SOFT_BITE)
         # highest bpe score and untreated teeth are only used after 1/10/2022
         if date_of_acceptance and date_of_acceptance >= datetime.date(2022, 10, 1):
-            if self.model_instance.highest_bpe_score is not None:
+            if self.model_instance.highest_bpe_score:
                 treatments.append(t.HIGHEST_BPE_SEXTANT_SCORE(
                     self.BPE_MAPPING[self.model_instance.highest_bpe_score]
                 ))


### PR DESCRIPTION
If you set a variable in the drop down box and then change that variable to --- then '' is stored in Fp17ClinicalDataSet.highest_bpe_score which errors on submission.

This change stops that behaviour.