### PR TITLE
Bug fixes the GDC Submission.

### DIFF
--- a/odonto/odonto_submissions/serializers.py
+++ b/odonto/odonto_submissions/serializers.py
@@ -966,7 +966,7 @@ def translate_to_fp17(bcds1, episode):
             dental_care_provider = episode.fp17dentalcareprovider_set.get()
             other_dental_professional = dental_care_provider.get_other_dental_professional()
             if other_dental_professional:
-                bcds1.gdc_number = other_dental_professional.gdc_number
+                bcds1.gdc_number = other_dental_professional.gdc_number.zfill(10)
                 dcp_lookup = {
                     "Therapist": 1,
                     "Hygienist": 2,


### PR DESCRIPTION
The spec constrains the GDC number to 10 digits, but the examples they give are e.g. 0000001234 and and the number users have given us was 1234. 

This change zfills the number on submission so we always fit the spec.

