### PR TITLE
Adds the test_local_settings option like RFH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov
 libpeerconnection.log
 .sass-cache
 odonto/local_settings.py
+odonto/local_test_settings.py
 *sqlite*
 .vscode
 .DS_Store

--- a/odonto/settings.py
+++ b/odonto/settings.py
@@ -1,5 +1,6 @@
 # Django settings for odonto project.
 import os
+import sys
 
 PROJECT_PATH = os.path.realpath(os.path.dirname(__file__))
 
@@ -372,3 +373,9 @@ try:
     from odonto.local_settings import *  # NOQA: F401
 except ImportError:
     pass
+
+if 'test' in sys.argv:
+    try:
+        from odonto.local_test_settings import *   # NOQA: F401
+    except ImportError:
+        pass


### PR DESCRIPTION
Allows the user to declare their own local test settings. The common use case for this is to declare MIGRATION_MODULES = {appname: None} which means that we do not run migrations for that app. This significantly speeds up unit tests.