### PR TITLE
Makes exemptions serialize in the now required order

### DIFF
--- a/odonto/odonto_submissions/serializers.py
+++ b/odonto/odonto_submissions/serializers.py
@@ -285,23 +285,43 @@ class Fp17OtherDentalServiceTranslator(TreatmentSerializer):
     }
 
 
+
+
 class ExceptionSerializer(object):
+    """
+    As of Processing rules 9.7 Paragraph 5.2.4 when there are more than
+    one exemption they should be sent down in the following order (Descending)
+    Patient Under 18
+    Expectant Mother
+    Nursing Mother
+    Aged 18 in FTE
+    Universal Credit
+    HC2 Certificate
+    Income Support
+    Employment Support Allowance
+    Tax Credits -- we do not have this for some reason?
+    Job Seeker’s Allowance
+    Pension Credits
+    Prisoner
+    HC3 Certificate
+    """
     EXEMPTION_MAPPINGS = {
-        "patient_under_18": e.PATIENT_UNDER_18,
-        "full_remission_hc2_cert": e.FULL_REMISSION,
-        "partial_remission_hc3_cert": e.PARTIAL_REMISSION,
-        "expectant_mother": e.EXPECTANT_MOTHER,
-        "nursing_mother": e.NURSING_MOTHER,
-        "aged_18_in_full_time_education": e.AGED_18_IN_FULL_TIME_EDUCATION,
-        "income_support": e.INCOME_SUPPORT,
+        "patient_under_18": e.PATIENT_UNDER_18, # 27, 28
+        "expectant_mother": e.EXPECTANT_MOTHER,  # 3, 4
+        "nursing_mother": e.NURSING_MOTHER,  # 5, 6
+        "aged_18_in_full_time_education": e.AGED_18_IN_FULL_TIME_EDUCATION,  # 1, 2
+        "universal_credit": e.UNIVERSAL_CREDIT,  # 38, 39
+        "full_remission_hc2_cert": e.FULL_REMISSION,  # 13, 14
+        "income_support": e.INCOME_SUPPORT,  # 17, 18
+        "income_related_employment_and_support_allowance": e.INCOME_RELATED_EMPLOYMENT_AND_SUPPORT_ALLOWANCE,  # 83, 84
         # "nhs_tax_credit_exemption" TODO this does not exist
-        "income_based_jobseekers_allowance": e.JOBSEEKERS_ALLOWANCE,
-        "pension_credit_guarantee_credit": e.PENSION_CREDIT_GUARANTEE_CREDIT,
-        "prisoner": e.PRISONER,
-        "universal_credit": e.UNIVERSAL_CREDIT,
-        "income_related_employment_and_support_allowance": e.INCOME_RELATED_EMPLOYMENT_AND_SUPPORT_ALLOWANCE,
+        "income_based_jobseekers_allowance": e.JOBSEEKERS_ALLOWANCE,  # 25, 26
+        "pension_credit_guarantee_credit": e.PENSION_CREDIT_GUARANTEE_CREDIT,  # 33, 34
+        "prisoner": e.PRISONER,  # 35
+        "partial_remission_hc3_cert": e.PARTIAL_REMISSION,  # 15, 16
         # "patient_charge_collected" TODO this is not exist
     }
+
 
     def __init__(self, model_instance):
         self.model_instance = model_instance
@@ -319,7 +339,9 @@ class ExceptionSerializer(object):
                     result["code"] = v.EVIDENCE_SEEN
                 else:
                     result["code"] = v.NO_EVIDENCE_SEEN
-
+                # We should only have one exemption per patient in the order
+                # from the dictionary
+                break
         return result
 
     def charge(self):

--- a/odonto/odonto_submissions/supplier_testing/fp17/case_60.py
+++ b/odonto/odonto_submissions/supplier_testing/fp17/case_60.py
@@ -1,0 +1,61 @@
+"""
+Tests that if we have multiple exemptions we only use the one that
+comes first
+"""
+import datetime
+from django.contrib.auth.models import User
+from odonto import models
+from odonto.odonto_submissions.serializers import translate_to_bdcs1
+from fp17 import treatments
+from fp17 import exemptions
+
+
+def annotate(bcds1):
+    bcds1.patient.surname = "BARLASTON"
+    bcds1.patient.forename = "SALLY"
+    bcds1.patient.address = ["1 HIGH STREET"]
+    bcds1.patient.sex = 'F'
+    bcds1.patient.date_of_birth = datetime.date(1958, 1, 23)
+    bcds1.patient.nhs_number = "7110493547"
+    bcds1.date_of_acceptance = datetime.date(2022, 10, 2)
+    bcds1.date_of_completion = datetime.date(2022, 10, 2)
+
+    bcds1.treatments = [
+        treatments.TREATMENT_CATEGORY(1),
+        treatments.NON_MOLAR_ENDONTIC_TREATMENT(1),
+        treatments.ETHNIC_ORIGIN_1_WHITE_BRITISH,
+    ]
+    bcds1.exemption_remission = {"code": exemptions.PATIENT_UNDER_18.NO_EVIDENCE_SEEN}
+
+    return bcds1
+
+
+def from_model(bcds1, patient, episode):
+    demographics = patient.demographics()
+    demographics.surname = "Barlaston"
+    demographics.first_name = "Sally"
+    demographics.house_number_or_name = "1"
+    demographics.street = "HIGH STREET"
+    demographics.sex = "Female"
+    demographics.date_of_birth = datetime.date(1958, 1, 23)
+    demographics.ethnicity = "White british"
+    demographics.hospital_number = "0123456789"
+    demographics.nhs_number = "711 049 3547"
+    demographics.save()
+    episode.fp17treatmentcategory_set.update(
+        treatment_category="Band 1",
+    )
+    episode.fp17incompletetreatment_set.update(
+        date_of_acceptance=datetime.date(2022, 10, 2),
+        completion_or_last_visit=datetime.date(2022, 10, 2)
+    )
+    episode.fp17clinicaldataset_set.update(
+        non_molar_endodontic_treatment=1
+    )
+    # We should only see the patient under 18 exemptiom
+    episode.fp17exemptions_set.update(
+        patient_under_18=True,
+        expectant_mother=True,
+    )
+
+    translate_to_bdcs1(bcds1, episode)

--- a/odonto/odonto_submissions/tests/test_serializors.py
+++ b/odonto/odonto_submissions/tests/test_serializors.py
@@ -141,7 +141,7 @@ class SerializerTestCase(OpalTestCase):
         fp17_category = episode_categories.FP17Episode.display_name
         fp17o_category = episode_categories.FP17OEpisode.display_name
         covid_19_category = episode_categories.CovidTriageEpisode.display_name
-        for case_number in range(1, 60):
+        for case_number in range(1, 61):
             new = from_model(case_number, fp17_category)
             old = from_message(case_number, fp17_category)
             self.assertTrue(equal(old, new))


### PR DESCRIPTION
There can only be one exemption, it used to be that what it was did not matter, the spec has changed as of 9.7 so that it now matters